### PR TITLE
Drop slim minimum version to 2.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "slim/slim": "~2.4.3",
+        "slim/slim": ">=2.4.3",
         "doctrine/orm": "~2.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "slim/slim": ">=2.4.3",
+        "slim/slim": "~2.4, >=2.4.3",
         "doctrine/orm": "~2.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "slim/slim": "~2.5",
+        "slim/slim": "~2.4.3",
         "doctrine/orm": "~2.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8c4e4343a0a6f908bd9a695387a44e00",
+    "hash": "9949a76e93cdd40bc47b5a746e179362",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "04b1eb2e4f475e79743e666d6e6824ca",
+    "hash": "8c4e4343a0a6f908bd9a695387a44e00",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
This code doesn't seem to use anything from 2.5, so would it be possible to drop the minimum slim version to 2.4.3?
